### PR TITLE
グループ機能の追加３

### DIFF
--- a/app/assets/stylesheets/_main-chat.scss
+++ b/app/assets/stylesheets/_main-chat.scss
@@ -2,6 +2,9 @@ $aqua:aqua;
 $grey:#434A54;
 .main-header{
   border-color: #eeeeee;
+  overflow: scroll;
+    overflow-x: scroll;
+    overflow-y: scroll;
   display: flex;
   justify-content: space-between;
   width: calc(100vw - 300px);
@@ -31,6 +34,9 @@ $grey:#434A54;
 
 .main-chat{
   background-color: #fafafa;
+  overflow: scroll;
+    overflow-x: scroll;
+    overflow-y: scroll;
   height: calc(100vh - 190px);
     &-all{
     padding-top: 46px;

--- a/app/assets/stylesheets/_side-bar.scss
+++ b/app/assets/stylesheets/_side-bar.scss
@@ -23,15 +23,20 @@ align-items: center;
 .side-contents {
 background-color: #2f3e51;
 width: 260px;
-height: calc(100vh - 100px);
+height: calc(100vh - 140px);
 padding:20px;
-  &__name{
-    @extend.irofont;
+overflow: scroll;
+  overflow-x: scroll;
+  overflow-y: scroll;
+  .content{
+    margin-bottom: 40px;
+    text-decoration: none;
+    color: white;
+    &__name{
     font-size: 15px;
-  }
-  &__message{
-    @extend.irofont;
+    }
+    &__message{
     font-size: 11px;
+    }
   }
-  
 }

--- a/app/controllers/groups_controller.rb
+++ b/app/controllers/groups_controller.rb
@@ -1,13 +1,40 @@
 class GroupsController < ApplicationController
+  before_action :set_group, only: [:edit, :update]
+  def index
+  end
+  
   def new
+    @group = Group.new
+    @group.users << current_user
   end
 
   def create
+    @group = Group.new(group_params)
+    if @group.save
+      redirect_to root_path, notice: 'グループを作成しました'
+    else
+      render :new
+    end
   end
 
   def edit
   end
 
   def update
+    if@group.update(group_params)
+      redirect_to group_messages_path(@group), notice: 'グループを編集しました'
+    else
+      render :edit
+    end  
   end
+
+  private
+  def group_params
+    params.require(:group).permit(:name, user_ids: [] )
+  end
+
+  def set_group
+    @group = Group.find(params[:id])
+  end
+
 end

--- a/app/models/group.rb
+++ b/app/models/group.rb
@@ -1,5 +1,5 @@
 class Group < ApplicationRecord
   has_many :messages
-  has_many :users, through: :users_groups
-  has_many :users_groups
+  has_many :users, through: :user_groups
+  has_many :user_groups
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -4,6 +4,6 @@ class User < ApplicationRecord
   devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :validatable
   has_many :messages
-  has_many :groups, through: :users_groups
-  has_many :users_groups
+  has_many :groups, through: :user_groups
+  has_many :user_groups
 end

--- a/app/views/groups/_form.html.haml
+++ b/app/views/groups/_form.html.haml
@@ -1,0 +1,24 @@
+= form_for @group do |f|
+  - if @group.errors.any?
+    .chat-group-form__errors
+      %h2= "#{@group.errors.full_messages.count}件のエラーが発生しました。"
+      %ul
+        - @group.errors.full_messages.each do |message|
+          %li= message
+  .chat-group-form__field
+    .chat-group-form__field--left
+      = f.label :name, class: 'chat-group-form__label'
+    .chat-group-form__field--right
+      = f.text_field :name, class: 'chat__group_name chat-group-form__input', placeholder: 'グループ名を入力してください'
+  .chat-group-form__field.clearfix
+    / この部分はインクリメンタルサーチ（ユーザー追加の非同期化)のときに使用します
+  .chat-group-form__field.clearfix
+    .chat-group-form__field--left
+      = f.label "チャットメンバー", class: "chat-group-form__label"
+    .chat-group-form__field--right
+      = f.collection_check_boxes :user_ids, User.all, :id, :name
+      / この部分はインクリメンタルサーチ（ユーザー追加の非同期化)のときにも使用します
+  .chat-group-form__field.clearfix
+    .chat-group-form__field--left
+    .chat-group-form__field--right
+      = f.submit class: 'chat-group-form__action-btn'

--- a/app/views/groups/edit.html.haml
+++ b/app/views/groups/edit.html.haml
@@ -1,25 +1,3 @@
 .chat-group-form
   %h1 チャットグループ編集
-  %form
-    .chat-group-form__errors
-      %h2
-        1件のエラーが発生しました。
-        %ul
-          %li エラーです
-    .chat-group-form__field
-      .chat-group-form__field--left
-        %label.chat-group-form__label{:for: "chat_group_name"} グループ名
-      .chat-group-form__field--right
-        %input#chat_group_name.chat-group-form__input{:name : "chat_group[name]", :placeholder : "グループ名を入力してください", :type : "text"}/
-    .chat-group-form__field
-      / この部分はインクリメンタルサーチ(ユーザー追加の非同期化)のときに使用します
-    .chat-group-form__field
-      .chat-group-form__field--left
-        %label.chat-group-form__label チャットメンバー
-      .chat-group-form__field--right
-        / グループ作成機能の追加時はここにcollection_check_boxesの記述を入れてください
-        / この部分はインクリメンタルサーチ(ユーザー追加の非同期化)のときにも使用します
-    .chat-group-form__field
-      .chat-group-form__field--left
-      .chat-group-form__field--right
-        %input.chat-group-form__action-btn{"data-disable-with" : "Save", :name : "commit", :type : "submit", :value : "Save"}/
+  = render 'form', { group: @group }

--- a/app/views/groups/index.html.haml
+++ b/app/views/groups/index.html.haml
@@ -1,0 +1,3 @@
+.wrapper
+  = render 'messages/side_bar'
+  = render 'messages/main_chat'

--- a/app/views/groups/new.html.haml
+++ b/app/views/groups/new.html.haml
@@ -1,25 +1,3 @@
 .chat-group-form
   %h1 新規チャットグループ
-  %form
-    .chat-group-form__errors
-      %h2
-        1件のエラーが発生しました。
-        %ul
-          %li エラーです
-    .chat-group-form__field
-      .chat-group-form__field--left
-        %label.chat-group-form__label{for: "chat_group_name"} グループ名
-      .chat-group-form__field--right
-        %input#chat_group_name.chat-group-form__input{name:  "chat_group[name]", placeholder:  "グループ名を入力してください", type: "text"}/
-    .chat-group-form__field
-      / この部分はインクリメンタルサーチ(ユーザー追加の非同期化)のときに使用します
-    .chat-group-form__field
-      .chat-group-form__field--left
-        %label.chat-group-form__label チャットメンバー
-      .chat-group-form__field--right
-        / グループ作成機能の追加時はここにcollection_check_boxesの記述を入れてください
-        / この部分はインクリメンタルサーチ(ユーザー追加の非同期化)のときにも使用します
-    .chat-group-form__field
-      .chat-group-form__field--left
-      .chat-group-form__field--right
-        %input.chat-group-form__action-btn{"data-disable-with": "Save", name: "commit", type: "submit", value: "Save"}/
+  = render 'form', { group: @group }

--- a/app/views/groups/new.html.haml
+++ b/app/views/groups/new.html.haml
@@ -8,9 +8,9 @@
           %li エラーです
     .chat-group-form__field
       .chat-group-form__field--left
-        %label.chat-group-form__label{:for => "chat_group_name"} グループ名
+        %label.chat-group-form__label{for: "chat_group_name"} グループ名
       .chat-group-form__field--right
-        %input#chat_group_name.chat-group-form__input{:name => "chat_group[name]", :placeholder => "グループ名を入力してください", :type => "text"}/
+        %input#chat_group_name.chat-group-form__input{name:  "chat_group[name]", placeholder:  "グループ名を入力してください", type: "text"}/
     .chat-group-form__field
       / この部分はインクリメンタルサーチ(ユーザー追加の非同期化)のときに使用します
     .chat-group-form__field
@@ -22,4 +22,4 @@
     .chat-group-form__field
       .chat-group-form__field--left
       .chat-group-form__field--right
-        %input.chat-group-form__action-btn{"data-disable-with" => "Save", :name => "commit", :type => "submit", :value => "Save"}/
+        %input.chat-group-form__action-btn{"data-disable-with": "Save", name: "commit", type: "submit", value: "Save"}/

--- a/app/views/messages/_main_chat.html.haml
+++ b/app/views/messages/_main_chat.html.haml
@@ -4,8 +4,9 @@
       group name
       .main-header__left--member-list
         Member
-    .main-header__edit-btn
-      Edit
+      = link_to edit_group_path(current_user),class: "edit" do
+        .main-header__edit-btn
+          Edit
   .main-chat
     .main-chat-all
       .main-chat-all__name

--- a/app/views/messages/_side_bar.html.haml
+++ b/app/views/messages/_side_bar.html.haml
@@ -9,10 +9,13 @@
       = link_to edit_user_path(current_user),class: "header__icon--haguruma" do
         = icon'fas','cog',class: "icon-color"
   .side-contents
-    .side-contents__name
-      test1
-    .side-contents__message
-      まだメッセージはありません
+    - current_user.groups.each do |group|
+      .content
+        = link_to group_messages_path(group) ,class:"content" do
+          .content__name
+            = group.name
+          .content__message
+            まだメッセージはありません
     
   
     

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,6 +1,8 @@
 Rails.application.routes.draw do
   devise_for :users
-  root to: "messages#index"
-  resources :users, only: [:edit, :update]
-  resources :groups, only: [:new, :create, :edit, :update]
+  root 'groups#index'
+  resources :users, only: [:index, :edit, :update]
+  resources :groups, only: [:new, :create, :edit, :update] do
+    resources :messages, only: [:index]
+  end
 end


### PR DESCRIPTION
#what
グループ作成　編集機能の追加

#why
グループ作成new、編集edit機能をform _forを使った書き方に変更
グループ作成と編集画面のhamlは _formファイルからrenderで呼び出すように変更

root toをgroup#indexに変更
hamlはmessageファイルからrenderで呼び出す形にした

グループ編集作成画面の実装に伴い、messageファイルのHAMLに編集、作成画面へのリンクを追加