### PR TITLE
メッセージ送信機能の作成３

### DIFF
--- a/app/models/group.rb
+++ b/app/models/group.rb
@@ -3,4 +3,11 @@ class Group < ApplicationRecord
   has_many :messages
   has_many :users, through: :user_groups
   has_many :user_groups
+  def show_last_message
+    if (last_message = messages.last).present?
+      last_message.body? ? last_message.body : '画像が投稿されています'
+    else
+      'まだメッセージはありません。'
+    end
+  end
 end

--- a/app/models/message.rb
+++ b/app/models/message.rb
@@ -3,4 +3,5 @@ class Message < ApplicationRecord
   belongs_to :user
   belongs_to :group
   validates :body, presence: true, unless: :image?
+  
 end

--- a/app/views/messages/_main_chat.html.haml
+++ b/app/views/messages/_main_chat.html.haml
@@ -1,9 +1,10 @@
 .main
   .main-header
     .main-header__left
-      group name
+      =@group.name
       .main-header__left--member-list
-        Member
+        - @group.users.each do |user|
+          = user.name
       = link_to edit_group_path(current_user),class: "edit" do
         .main-header__edit-btn
           Edit

--- a/app/views/messages/_side_bar.html.haml
+++ b/app/views/messages/_side_bar.html.haml
@@ -15,7 +15,7 @@
           .content__name
             = group.name
           .content__message
-            未実装
+            = group.show_last_message
     
   
     


### PR DESCRIPTION
#what
サイドバー内の各グループ名の下に最後に送信したメッセージを表示するように変更
グループ名を押した時グループ詳細画面

#why
メッセージ送信機能作成